### PR TITLE
Increase max log display to 30 days

### DIFF
--- a/mlp/static/js/local_settings.js
+++ b/mlp/static/js/local_settings.js
@@ -23,7 +23,7 @@
                             <div style="display:none" id="default_period_div">
                                 <div v-if="!$parent.loading" :title="$parent.localeData.user_settings.show_last_min_title" class="ui field"><i class="clock icon"/><label style="display:inline" v-if="!$parent.loading" v-html="$parent.localeData.user_settings.show_last_min"></label> {{ settings.default_period_processed }} </div>
                                 <div class="ui input">
-                                    <input v-if="!$parent.loading" v-model="settings.default_period" type="range" step="5" min="5" max="4320" :title="$parent.localeData.user_settings.show_last_min_title" class="ui input range">
+                                    <input v-if="!$parent.loading" v-model="settings.default_period" type="range" step="5" min="5" max="43200" :title="$parent.localeData.user_settings.show_last_min_title" class="ui input range">
                                 </div>
                             </div>
                             <div v-if="settings.refresh !== 0" class="ui field"><i class="sync icon"/><label style="display:inline" v-if="!$parent.loading" v-html="$parent.localeData.user_settings.refresh"></label> {{ settings.refresh }} <label style="display:inline" v-if="!$parent.loading" v-html="$parent.localeData.user_settings.refresh_end"></label></div>


### PR DESCRIPTION
Previously, the limit was lower, but extending it to 30 days provides better coverage for users needing a longer history.